### PR TITLE
Actualizo Circle CI para ignorar GH Pages Branch

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -2,6 +2,8 @@ version: 2
 jobs:
   build:
     branches:
+      ignore:
+        - gh-pages
       only:
         - master
     docker:


### PR DESCRIPTION
Dejo este pequeño PR basandome en la doc de circle ci (https://circleci.com/docs/2.0/configuration-reference/) para ignorar el branch de gh-pages y no haga build sobre ese branch 

Actualmente buildea tanto master como gh-pages y este ultimo no hace falta. Algunos de los fallos se pueden ver en el UI de Circle CI (https://app.circleci.com/pipelines/github/uqbar-project/uqbar-landing/101/workflows/449f43b0-1d14-4ca4-881e-d21d68205e92)